### PR TITLE
Added support for pvvx Zigbee firmware fork

### DIFF
--- a/drivers/xiaomi-thermometer-zigbee/driver.compose.json
+++ b/drivers/xiaomi-thermometer-zigbee/driver.compose.json
@@ -21,7 +21,7 @@
   },
   "zigbee": {
     "manufacturerName": "Xiaomi",
-    "productId": [ "LYWSD03MMC" ],
+    "productId": [ "LYWSD03MMC", "LYWSD03MMC-z" ],
     "endpoints": {
       "1": {
         "clusters": [0, 1, 1026, 1029],


### PR DESCRIPTION
See [this forum post](https://community.homey.app/t/xiaomi-miija-temperature-and-humidity/78560/47).